### PR TITLE
feat(remittance): add normalized international beneficiary form fields

### DIFF
--- a/src/app/(dashboard)/_components/send/usd/bankTransfer/toGlobal/CNBeneficiaryForm.tsx
+++ b/src/app/(dashboard)/_components/send/usd/bankTransfer/toGlobal/CNBeneficiaryForm.tsx
@@ -8,6 +8,7 @@ import { useUser } from "@/lib/hooks/useUser";
 import { CreateIntBeneficiary } from "@/services/transactions";
 import {
   FormField,
+  IntBeneficiaryMethodFields,
   IIntBeneficiaryPayload,
   IntCountryType,
 } from "@/types/services";
@@ -30,10 +31,6 @@ import IdSelectModal from "./IdSelectModal";
 
 export type cnBenType = "BANK" | "ALIPAY" | "WECHATPAY" | null;
 
-interface FieldEntry {
-  [key: string]: FormField[];
-}
-
 interface FieldsMap {
   [key: string]: FormField[];
   BANK: FormField[];
@@ -42,7 +39,7 @@ interface FieldsMap {
 }
 
 interface Props {
-  fields: FieldEntry[];
+  methods: IntBeneficiaryMethodFields;
   countryCode: IntCountryType;
   countryName: string;
   bankDetailsFields?: { name: string; label: string; pattern?: string }[];
@@ -54,7 +51,7 @@ interface FormValues {
 }
 
 const CNBeneficiaryForm = ({
-  fields,
+  methods,
   countryCode,
   countryName,
   bankDetailsFields = [],
@@ -82,14 +79,12 @@ const CNBeneficiaryForm = ({
   });
   const [bankCurrency, setBankCurrency] = useState<"USD" | "CNY">("CNY");
   const typeFields = ["BANK", "ALIPAY", "WECHATPAY"] as cnBenType[];
-  const fieldsMap: FieldsMap = fields.reduce<FieldsMap>(
-    (acc, entry) => {
-      const key = Object.keys(entry)[0] as "BANK" | "ALIPAY" | "WECHATPAY";
-      acc[key] = entry[key];
-      return acc;
-    },
-    { BANK: [], ALIPAY: [], WECHATPAY: [] }
-  );
+  const fieldsMap: FieldsMap = {
+    BANK: methods.BANK || [],
+    ALIPAY: methods.ALIPAY || [],
+    WECHATPAY: methods.WECHATPAY || [],
+    ...methods,
+  };
   const formDetail = type !== null ? fieldsMap[type] || [] : [];
   const bankDetailsFieldNames = bankDetailsFields.map((field) => field.name);
   // console.log("bbb", bankDetailsFieldNames);
@@ -421,8 +416,8 @@ const CNBeneficiaryForm = ({
             </label>
             <div className="flex flex-col gap-3">
               {subField.enum.map((option) => (
-                <button
-                  type="button"
+                <div
+                role="button"
                   onClick={() => formik.setFieldValue(fieldName, option)}
                   key={option}
                   className="flex items-center gap-2"
@@ -437,7 +432,7 @@ const CNBeneficiaryForm = ({
                       .toLowerCase()
                       .replace(/^./, (c) => c.toUpperCase())}
                   </span>
-                </button>
+                </div>
               ))}
             </div>
             {formik.errors[fieldName] && formik.touched[fieldName] && (
@@ -646,7 +641,9 @@ const CNBeneficiaryForm = ({
   };
   return (
     <div className="my-5">
+            <p className=" text-sm font-medium font-brSonoma leading-normal mb-3 text-yellow-500">Note: For China BANK transfers, Sender name and beneficiary name must exactly match the name on the attached invoice</p>
       <InputLabel content="Send type" />
+
       <ModalTrigger
         onClick={() => setOpenModal("type")}
         placeholder="Select type "
@@ -754,8 +751,8 @@ const CNBeneficiaryForm = ({
                     </label>
                     <div className="flex flex-col gap-3">
                       {field.enum.map((option) => (
-                        <button
-                          type="button"
+                        <div
+                          role="button"
                           onClick={() =>
                             formik.setFieldValue(field.name, option)
                           }
@@ -774,7 +771,7 @@ const CNBeneficiaryForm = ({
                               .toLowerCase()
                               .replace(/^./, (c) => c.toUpperCase())}
                           </span>
-                        </button>
+                        </div>
                       ))}
                     </div>
                     {formik.errors[field.name] &&

--- a/src/app/(dashboard)/_components/send/usd/bankTransfer/toGlobal/DynamicBeneficiaryForm.tsx
+++ b/src/app/(dashboard)/_components/send/usd/bankTransfer/toGlobal/DynamicBeneficiaryForm.tsx
@@ -3,7 +3,11 @@ import Button from "@/components/ui/Button";
 import InputField from "@/components/ui/InputField";
 import Radio from "@/components/ui/Radio";
 import { GlobalCountryConfig } from "@/constants/send";
-import { FormField, IntCountryType } from "@/types/services";
+import {
+  FormField,
+  IntBeneficiaryMethodFields,
+  IntCountryType,
+} from "@/types/services";
 import { convertField } from "@/utils/helpers";
 import { FormikProps } from "formik";
 import React, { useEffect } from "react";
@@ -11,14 +15,16 @@ import React, { useEffect } from "react";
 interface Props {
   fields: FormField[];
   formik: FormikProps<any>;
-  fieldsData: Record<string, FormField[]>;
+  countryMethods: IntBeneficiaryMethodFields;
+  activeMethod: string;
   reset: () => void;
 }
 
 const DynamicBeneficiaryForm = ({
   fields,
   formik,
-  fieldsData,
+  countryMethods,
+  activeMethod,
   reset,
 }: Props) => {
   useEffect(() => {
@@ -143,12 +149,14 @@ const DynamicBeneficiaryForm = ({
   } = config;
   const FormComponent = formComponent;
 
+  const methodFields = activeMethod ? countryMethods[activeMethod] || [] : fields;
+  const fallbackFields = Object.values(countryMethods).flat();
   const banks =
     (defaultBanks?.length ?? 0) > 0
       ? defaultBanks
-      : fieldsData?.[countryCode]?.find(
-          (field: any) => field.name === "bank_code"
-        )?.banks || [];
+      : methodFields.find((field: any) => field.name === "bank_code")?.banks ||
+        fallbackFields.find((field: any) => field.name === "bank_code")?.banks ||
+        [];
 
   return (
     <FormComponent

--- a/src/app/(dashboard)/_components/send/usd/bankTransfer/toGlobal/GbBeneficiaryForm.tsx
+++ b/src/app/(dashboard)/_components/send/usd/bankTransfer/toGlobal/GbBeneficiaryForm.tsx
@@ -4,6 +4,7 @@ import { convertField, getReadablePatternMessage } from "@/utils/helpers";
 import React, { useState } from "react";
 import {
   FormField,
+  IntBeneficiaryMethodFields,
   IIntBeneficiaryPayload,
   IntCountryType,
 } from "@/types/services";
@@ -27,10 +28,6 @@ import BeneficiaryTypeModal from "../toInternational/BeneficiaryTypeModal";
 
 export type gbBenType = "DOMESTIC_GBP" | "SEPA_EUR" | null;
 
-interface FieldEntry {
-  [key: string]: FormField[];
-}
-
 interface FieldsMap {
   [key: string]: FormField[];
   DOMESTIC_GBP: FormField[];
@@ -38,7 +35,7 @@ interface FieldsMap {
 }
 
 interface Props {
-  fields: FieldEntry[];
+  methods: IntBeneficiaryMethodFields;
   countryCode: IntCountryType;
 }
 
@@ -47,7 +44,7 @@ interface FormValues {
   [key: string]: any;
 }
 
-const GbBeneficiaryForm = ({ fields, countryCode }: Props) => {
+const GbBeneficiaryForm = ({ methods, countryCode }: Props) => {
   const { user } = useUser();
   const [showModal, setShowModal] = useState<
     "type" | null | "purpose" | "ben" | "send"
@@ -63,14 +60,11 @@ const GbBeneficiaryForm = ({ fields, countryCode }: Props) => {
   });
   const [type, setType] = useState<gbBenType>(null);
   const typeFields = ["DOMESTIC_GBP", "SEPA_EUR"] as gbBenType[];
-  const fieldsMap: FieldsMap = fields.reduce<FieldsMap>(
-    (acc, entry) => {
-      const key = Object.keys(entry)[0] as "DOMESTIC_GBP" | "SEPA_EUR";
-      acc[key] = entry[key];
-      return acc;
-    },
-    { DOMESTIC_GBP: [], SEPA_EUR: [] },
-  );
+  const fieldsMap: FieldsMap = {
+    DOMESTIC_GBP: methods.DOMESTIC_GBP || [],
+    SEPA_EUR: methods.SEPA_EUR || [],
+    ...methods,
+  };
 
   const entity = user?.business_account?.entity;
   const userName = `${user?.first_name || ""} ${user?.last_name || ""}`.trim();

--- a/src/app/(dashboard)/_components/send/usd/bankTransfer/toGlobal/GlobalBeneficiary.tsx
+++ b/src/app/(dashboard)/_components/send/usd/bankTransfer/toGlobal/GlobalBeneficiary.tsx
@@ -17,6 +17,7 @@ import {
 import { useSendStore } from "@/store/Send";
 import {
   FormField,
+  IntBeneficiaryMethodFields,
   IIntBeneficiariesParams,
   IIntBeneficiaryPayload,
   IntCountryType,
@@ -26,6 +27,7 @@ import {
   getReadablePatternMessage,
   truncateString,
 } from "@/utils/helpers";
+import { resolveCountryMethodFields } from "@/utils/remittanceFormFields";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { FormikConfig, useFormik } from "formik";
 import React, { useEffect, useState } from "react";
@@ -64,6 +66,10 @@ const GlobalBeneficiary = ({ close }: Props) => {
   >(null);
   const [bank, setBank] = useState<IBank>();
   const [fields, setFields] = useState<FormField[]>([]);
+  const [countryMethods, setCountryMethods] = useState<IntBeneficiaryMethodFields>(
+    {},
+  );
+  const [selectedMethod, setSelectedMethod] = useState<string>("");
   const [isValid, setIsValid] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const { data: fieldsData, isLoading: fieldLoading } = useQuery({
@@ -110,8 +116,23 @@ const GlobalBeneficiary = ({ close }: Props) => {
       let fieldSchema = z.string();
 
       // Add required validation
-      if (field.required) {
+      if (field.required && !field.const) {
         fieldSchema = fieldSchema.min(1, `${field.name} is required`);
+      }
+
+      const minLength = field.min_length ?? field.minLength;
+      const maxLength = field.max_length ?? field.maxLength;
+      if (typeof minLength === "number" && minLength > 0) {
+        fieldSchema = fieldSchema.min(
+          minLength,
+          `${field.name} must be at least ${minLength} characters`,
+        );
+      }
+      if (typeof maxLength === "number" && maxLength > 0) {
+        fieldSchema = fieldSchema.max(
+          maxLength,
+          `${field.name} must be at most ${maxLength} characters`,
+        );
       }
 
       // Add pattern validation if it exists
@@ -199,34 +220,57 @@ const GlobalBeneficiary = ({ close }: Props) => {
     },
   });
 
-  // Update fields and validation when country changes
-  useEffect(() => {
-    if (fieldsData && formik.values.country) {
-      const newFields: FormField[] =
-        typeof formik.values.country === "string" || !formik.values.country
-          ? []
-          : (fieldsData?.[formik.values.country.value] as FormField[]) || [];
+  const countryCode =
+    typeof formik.values.country === "string" || !formik.values.country
+      ? ""
+      : formik.values.country.value;
 
-      setFields(newFields);
-      formik.setFormikState((prev) => ({
-        ...prev,
-        validationSchema: toFormikValidationSchema(
-          createValidationSchema(newFields),
-        ),
-      }));
-      const newValues: FormValues = {
-        country: formik.values.country,
-        ...newFields.reduce<Record<string, string>>(
-          (acc: Record<string, string>, field: FormField) => {
-            acc[field.name] = formik.values[field.name] || "";
-            return acc;
-          },
-          {},
-        ),
-      };
-      formik.setValues(newValues);
+  // Update fields and validation when country/method changes
+  useEffect(() => {
+    if (!fieldsData || !countryCode) {
+      setFields([]);
+      setCountryMethods({});
+      setSelectedMethod("");
+      return;
     }
-  }, [formik.values.country, fieldsData]);
+
+    const resolved = resolveCountryMethodFields(
+      fieldsData,
+      countryCode,
+      selectedMethod,
+    );
+
+    if (!resolved.activeMethod) {
+      setFields([]);
+      setCountryMethods({});
+      setSelectedMethod("");
+      return;
+    }
+
+    if (resolved.activeMethod !== selectedMethod) {
+      setSelectedMethod(resolved.activeMethod);
+    }
+
+    setCountryMethods(resolved.methods);
+    setFields(resolved.fields);
+    formik.setFormikState((prev) => ({
+      ...prev,
+      validationSchema: toFormikValidationSchema(
+        createValidationSchema(resolved.fields),
+      ),
+    }));
+    const newValues: FormValues = {
+      country: formik.values.country,
+      ...resolved.fields.reduce<Record<string, string>>(
+        (acc: Record<string, string>, field: FormField) => {
+          acc[field.name] = formik.values[field.name] || field.const || "";
+          return acc;
+        },
+        {},
+      ),
+    };
+    formik.setValues(newValues);
+  }, [countryCode, fieldsData, selectedMethod]);
 
   useEffect(() => {
     const result = NGNAcctNoSchema.safeParse(NgFormik.values.account_number);
@@ -358,6 +402,24 @@ const GlobalBeneficiary = ({ close }: Props) => {
                 : formik.values.country?.name || ""
             }
           />
+          {Object.keys(countryMethods).length > 1 &&
+            formik.values.country?.value !== "GB" &&
+            formik.values.country?.value !== "CN" && (
+              <div className="mt-4">
+                <InputLabel content="Payout Method" />
+                <select
+                  className="w-full mt-2 rounded-xl border border-raiz-gray-200 px-4 py-3 bg-white text-raiz-gray-900"
+                  value={selectedMethod}
+                  onChange={(event) => setSelectedMethod(event.target.value)}
+                >
+                  {Object.keys(countryMethods).map((method) => (
+                    <option value={method} key={method}>
+                      {method}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
 
           {fields.length > 0 && formik.values.country?.value === "NG" && (
             <form
@@ -399,15 +461,13 @@ const GlobalBeneficiary = ({ close }: Props) => {
           )}
           {fields.length > 0 && formik.values.country?.value === "GB" && (
             <GbBeneficiaryForm
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              fields={fields as any}
+              methods={countryMethods}
               countryCode={formik.values.country.value}
             />
           )}
           {fields.length > 0 && formik.values.country?.value === "CN" && (
             <CNBeneficiaryForm
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              fields={fields as any}
+              methods={countryMethods}
               countryCode={formik.values.country.value}
               countryName={"China"}
               bankDetailsFields={[
@@ -433,7 +493,8 @@ const GlobalBeneficiary = ({ close }: Props) => {
               <DynamicBeneficiaryForm
                 fields={fields}
                 formik={formik}
-                fieldsData={fieldsData || {}}
+                countryMethods={countryMethods}
+                activeMethod={selectedMethod}
                 reset={() => formik.resetForm()}
               />
             )}

--- a/src/services/transactions.ts
+++ b/src/services/transactions.ts
@@ -30,8 +30,10 @@ import {
   IUsBeneficiariesParams,
   IUsBeneficiariesResponse,
   IUsBeneficiaryPayload,
+  NormalizedIntBeneficiaryFormFields,
   VolumeAndActivityData,
 } from "@/types/services";
+import { normalizeRemittanceFormFields } from "@/utils/remittanceFormFields";
 import {
   INgnTempPaymentLinkPayload,
   IRate,
@@ -393,11 +395,12 @@ export const SendCryptoApi = async (
   return response?.data;
 };
 
-export const GetIntBeneficiaryFormFields = async () => {
+export const GetIntBeneficiaryFormFields =
+  async (): Promise<NormalizedIntBeneficiaryFormFields> => {
   const response = await AuthAxios.get(
     `/business/transactions/remittance/form-fields/`,
   );
-  return response?.data;
+  return normalizeRemittanceFormFields(response?.data);
 };
 
 export const FetchIntBeneficiariesApi = async (

--- a/src/types/services.ts
+++ b/src/types/services.ts
@@ -324,6 +324,26 @@ export interface FormField {
   banks?: IBeneficiaryBank[];
 }
 
+export type IntBeneficiaryMethodFields = Record<string, FormField[]>;
+
+export type IntBeneficiaryCountryRawEntry = FormField | IntBeneficiaryMethodFields;
+
+export type IntBeneficiaryCountryRaw = IntBeneficiaryCountryRawEntry[];
+
+export type IntBeneficiaryFormFieldsRaw = Record<string, IntBeneficiaryCountryRaw>;
+
+export interface NormalizedIntBeneficiaryCountryFields {
+  methods: IntBeneficiaryMethodFields;
+  methodEntries: IntBeneficiaryMethodFields[];
+  defaultMethod: string;
+  flatFields: FormField[];
+}
+
+export type NormalizedIntBeneficiaryFormFields = Record<
+  string,
+  NormalizedIntBeneficiaryCountryFields
+>;
+
 export interface IUsBeneficiaryPayload {
   optionType: IUsBeneficiaryOptionType;
   label: string;

--- a/src/utils/remittanceFormFields.ts
+++ b/src/utils/remittanceFormFields.ts
@@ -1,0 +1,186 @@
+import {
+  FormField,
+  IntBeneficiaryCountryRaw,
+  IntBeneficiaryMethodFields,
+  NormalizedIntBeneficiaryCountryFields,
+  NormalizedIntBeneficiaryFormFields,
+} from "@/types/services";
+
+const DEFAULT_METHOD = "DEFAULT";
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const inferFallbackName = (field: Record<string, unknown>) => {
+  if (typeof field.const === "string") {
+    return "type";
+  }
+
+  if (Array.isArray(field.enum) && field.enum.length > 0) {
+    return "type";
+  }
+
+  return "";
+};
+
+const normalizeFormField = (input: unknown): FormField | null => {
+  if (!isObject(input)) {
+    return null;
+  }
+
+  const rawName = typeof input.name === "string" ? input.name : "";
+  const name = rawName || inferFallbackName(input);
+  const type = typeof input.type === "string" ? input.type : "string";
+  const required = Boolean(input.required);
+
+  if (!name) {
+    return null;
+  }
+
+  const enumValues = Array.isArray(input.enum)
+    ? input.enum.filter((value): value is string => typeof value === "string")
+    : undefined;
+  const minLength =
+    typeof input.min_length === "number"
+      ? input.min_length
+      : typeof input.minLength === "number"
+        ? input.minLength
+        : undefined;
+  const maxLength =
+    typeof input.max_length === "number"
+      ? input.max_length
+      : typeof input.maxLength === "number"
+        ? input.maxLength
+        : undefined;
+  const nestedFields = Array.isArray(input.fields)
+    ? input.fields
+        .map((field) => normalizeFormField(field))
+        .filter((field): field is FormField => Boolean(field))
+    : undefined;
+
+  return {
+    name,
+    type,
+    required,
+    enum: enumValues && enumValues.length ? enumValues : undefined,
+    min_length: minLength,
+    minLength,
+    max_length: maxLength,
+    maxLength,
+    pattern: typeof input.pattern === "string" ? input.pattern : undefined,
+    const: typeof input.const === "string" ? input.const : undefined,
+    fields: nestedFields && nestedFields.length ? nestedFields : undefined,
+    banks: Array.isArray(input.banks)
+      ? (input.banks as FormField["banks"])
+      : undefined,
+  };
+};
+
+const isMethodBucket = (entry: unknown): entry is IntBeneficiaryMethodFields => {
+  if (!isObject(entry)) {
+    return false;
+  }
+
+  const keys = Object.keys(entry);
+  if (keys.length !== 1) {
+    return false;
+  }
+
+  const bucket = entry[keys[0]];
+  return Array.isArray(bucket);
+};
+
+const normalizeMethodFields = (fields: unknown[]): FormField[] =>
+  fields
+    .map((field) => normalizeFormField(field))
+    .filter((field): field is FormField => Boolean(field));
+
+const normalizeCountry = (
+  countryFields: IntBeneficiaryCountryRaw,
+): NormalizedIntBeneficiaryCountryFields => {
+  const methods: IntBeneficiaryMethodFields = {};
+  const sharedFields: FormField[] = [];
+
+  countryFields.forEach((entry) => {
+    if (isMethodBucket(entry)) {
+      const method = Object.keys(entry)[0];
+      const methodFields = normalizeMethodFields(entry[method] as unknown[]);
+      methods[method] = methodFields;
+      return;
+    }
+
+    const normalizedField = normalizeFormField(entry);
+    if (normalizedField) {
+      sharedFields.push(normalizedField);
+    }
+  });
+
+  if (!Object.keys(methods).length) {
+    methods[DEFAULT_METHOD] = sharedFields;
+  } else if (sharedFields.length) {
+    Object.keys(methods).forEach((method) => {
+      methods[method] = [...sharedFields, ...methods[method]];
+    });
+  }
+
+  const methodKeys = Object.keys(methods);
+  const preferredDefaults = ["BANK", "SWIFT", DEFAULT_METHOD];
+  const defaultMethod =
+    preferredDefaults.find((method) => methods[method]) || methodKeys[0];
+  const flatFields = methods[defaultMethod] || [];
+  const methodEntries = methodKeys.map((method) => ({ [method]: methods[method] }));
+
+  return {
+    methods,
+    methodEntries,
+    defaultMethod,
+    flatFields,
+  };
+};
+
+export const normalizeRemittanceFormFields = (
+  raw: unknown,
+): NormalizedIntBeneficiaryFormFields => {
+  if (!isObject(raw)) {
+    return {};
+  }
+
+  const normalized: NormalizedIntBeneficiaryFormFields = {};
+  Object.entries(raw).forEach(([countryCode, fields]) => {
+    if (!Array.isArray(fields)) {
+      return;
+    }
+    normalized[countryCode] = normalizeCountry(fields as IntBeneficiaryCountryRaw);
+  });
+
+  return normalized;
+};
+
+export const resolveCountryMethodFields = (
+  fieldsData: NormalizedIntBeneficiaryFormFields | undefined,
+  countryCode: string,
+  method?: string,
+) => {
+  const countryFields = fieldsData?.[countryCode];
+  if (!countryFields) {
+    return {
+      availableMethods: [] as string[],
+      activeMethod: "",
+      fields: [] as FormField[],
+      methods: {} as IntBeneficiaryMethodFields,
+      methodEntries: [] as IntBeneficiaryMethodFields[],
+    };
+  }
+
+  const availableMethods = Object.keys(countryFields.methods);
+  const activeMethod =
+    method && countryFields.methods[method] ? method : countryFields.defaultMethod;
+
+  return {
+    availableMethods,
+    activeMethod,
+    fields: countryFields.methods[activeMethod] || [],
+    methods: countryFields.methods,
+    methodEntries: countryFields.methodEntries,
+  };
+};


### PR DESCRIPTION
- Add TypeScript type definitions for raw and normalized international beneficiary form fields
- Create `normalizeRemittanceFormFields` utility to transform raw API responses into structured, method-based field data, enabling support for multiple payout methods per country
- Update `GetIntBeneficiaryFormFields` API function to return typed normalized data instead of raw response
- Refactor GB, CN, and dynamic beneficiary form components to replace the old raw field entry format with the new normalized structure
- Add dynamic payout method selection dropdown in the global beneficiary form for countries with multiple available options
- Fix accessibility issues in CNBeneficiaryForm by replacing non-semantic button wrappers with div elements with `role="button"`
- Add proper min/max length validation handling in the global beneficiary form
- Update form value initialization to respect field const values for pre-filled fields

## 📌 Ticket Description

Brief summary of what this ticket is about.

---

## 📚 Related Documentation

- Link to specs, designs, ADRs, or API docs

---

## 🔧 Changes Made

- [ ] Logic changes
- [ ] API changes
- [ ] DB changes
- [ ] UI changes

**Details:**

- File A: explanation
- File B: explanation

---

## 🔗 Jira Ticket

https://your-jira-url/browse/RAZ-123

---

## 🧪 Testing Done

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing

**How to test locally:**

1.
2.
3.

---

## ⚠️ Notes / Risks

Any risk, migration, or rollout notes
